### PR TITLE
Fix sounds effects sometimes not playing

### DIFF
--- a/src/Main executable/Cdirsnd.cpp
+++ b/src/Main executable/Cdirsnd.cpp
@@ -155,36 +155,10 @@ UINT CDirSound::DuplicateSoundBuffer(UINT bufferNum) {
     if (!srcChunk)
         return 0;
 
-    char* waveData = (char*)srcChunk->abuf;
-    DWORD waveSize = srcChunk->alen;
-    LPWAVEFORMATEX waveFormat = ((CWave*)srcChunk->allocated)->GetWaveFormatPtr();
-    if (!waveFormat) {
-        return 0;
-    }
-
-    char headerBuf[44];
-    DWORD headerSize;
-    CreateWAVHeader(waveFormat, waveSize, headerBuf, &headerSize);
-    char* wavData = new char[headerSize + waveSize];
-    memcpy(wavData, headerBuf, headerSize);
-    memcpy(wavData + headerSize, waveData, waveSize);
-
-    SDL_RWops* rw = SDL_RWFromMem(wavData, headerSize + waveSize);
-    if (!rw) {
-        delete[] wavData;
-        return 0;
-    }
-
-    Mix_Chunk* chunk = Mix_LoadWAV_RW(rw, 0);
-    SDL_RWclose(rw);
-    delete[] wavData;
-    if (!chunk) {
-        return 0;
-    }
-
-    m_bufferPointers[m_currentBufferNum] = chunk;
-    m_bufferSizes[m_currentBufferNum] = waveSize;
+    m_bufferPointers[m_currentBufferNum] = srcChunk;
+    m_bufferSizes[m_currentBufferNum] = srcChunk->alen;
     Volume[m_currentBufferNum] = Volume[bufferNum];
+
     return m_currentBufferNum;
 }
 

--- a/src/Main executable/Ddini.cpp
+++ b/src/Main executable/Ddini.cpp
@@ -405,6 +405,14 @@ bool CreateDDObjects(HWND hwnd_param) {
         style |= WS_SYSMENU;
         SetWindowLong(hwnd_param, GWL_STYLE, style);
         SetWindowPos(hwnd_param, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
+        // Clean and update the render
+        if (bActive && gRenderer) {
+            SDL_SetRenderDrawColor(gRenderer, 0, 0, 0, 255);
+            SDL_RenderClear(gRenderer);
+            SDL_RenderPresent(gRenderer);
+            printf("Menu: Render updated with RealLx=%d, RealLy=%d\n", RealLx, RealLy);
+        }
     }
     if ((InGame || InEditor) && window_mode) {
         if (isWine) {


### PR DESCRIPTION
Mix_Chunk does not have a copy/duplicate function in sdl_mixer. Also no way to easily recreate the chunk. We can however just point to the existing chunk. This allows the sound effects to still be distributed by the order in soundlist.txt.

Fixes #5 