### PR TITLE
Fix networking stack in direct tcp/ip mode and in the shell behind NAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ To avoid entering this variable every time, you can add it to the configuration 
 
 
 
+# Fixed Networking (Fork by emilekm2142)
+
+**Direct TCP/IP now uses CommCore (UDP) instead of DirectPlay.** Previously, the "Direct TCP/IP" multiplayer option (where you enter an IP address) used DirectPlay, which fails behind symmetric NAT and VPNs like Hamachi. This fork reroutes Direct TCP/IP connections through CommCore's UDP-based networking stack (port 34000), enabling reliable connections over Hamachi and similar VPN tools.
+
+**Stone mining upgrade cap raised from 400% to 800%.** The academy stone efficiency upgrades compound multiplicatively, which was capped at 400%. The cap has been raised to 800% to allow the full effect of both upgrades.
+
 #  🙏 Acknowledgments
 
 I would like to thank the esteemed ereb-thanatos for the massive work on version 1.42. GitHub repository [ereb-thanatos](https://github.com/ereb-thanatos/cossacks-revamp-2017)

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,3 @@
+@echo off
+"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" "%~dp0src\Cossacks.sln" -nologo -v:minimal
+pause

--- a/src/Main executable/MPlayer.cpp
+++ b/src/Main executable/MPlayer.cpp
@@ -62,6 +62,11 @@ Menu StartMultiplayer;
 word PlayerMenuMode;
 word PrevRpos;
 extern bool DoNewInet;
+void IPCORESetAndSendUserData(byte* pData, unsigned short size)
+{
+	IPCORE.SetUserData(pData, size);
+	IPCORE.SendUserData();
+}
 extern int COUNTER;
 bool ProcessMessages();
 int WaitCycle;
@@ -1772,7 +1777,11 @@ bool CreateNamedSession( char* Name, DWORD User2, int Max )
 		IPCORE.SetOptions( User2 );
 		IPCORE.SetMaxPeers( Max );
 		bool r = ( IPCORE.InitServer( Name, Name ) != 0 );
-		if (r)IPCORE_INIT = 1;
+		if (r)
+		{
+			IPCORE_INIT = 1;
+			MyDPID = IPCORE.GetPeerID();
+		}
 		return r;
 	}
 	else

--- a/src/Main executable/NewUpgrade.cpp
+++ b/src/Main executable/NewUpgrade.cpp
@@ -1405,9 +1405,9 @@ void PerformNewUpgrade( Nation* NT, int UIndex, OneObject* OB )
 	{
 		int val = NT->StoneEff;
 		UseValue( &val, NU->ValueType, NU->Value );
-		if (400 < val)
+		if (800 < val)
 		{
-			val = 400;//just in case
+			val = 800;//just in case
 		}
 		NT->StoneEff = val;
 	}


### PR DESCRIPTION
Hi
Me and my friend have been facing a problem with direct tcp/ip connection ever since we changed our ISPs. We realized that one player is behind a symmetric NAT and the other one is behind a cone NAT. We could not connect to each other games with radmin, hamachi, zero tier nor tailscale and the shell. The workaround was to have someone host the game in the shell and then join him and play with the third player as a spectator.

Take a look at changes made to the networking. It fixes the issue and we are able to play the game again after 2+ years. 

If you decide you want to incorporate this I could clean up the fork to get rid of readme changes and remove the stone efficiency thing ;p.

Yes it was all made by Opus 4.6 ;(